### PR TITLE
make eslint config env agnostic

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -2,7 +2,6 @@ const prettierConfig = require('@lovetoknow/prettier-config')
 
 module.exports = {
   extends: ['eslint:recommended', 'plugin:prettier/recommended'],
-  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
   },


### PR DESCRIPTION
If I understand correctly, the babel parser should only be used if you are using babel, which makes this a little problematic for node projects.

Maybe there should be extensions that are for a targeted env or purpose?