### PR TITLE
feat(eslint-config): add all eslint-plugin-vuejs-accessibility rules …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3484,6 +3484,12 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "aria-query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+      "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+      "dev": true
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -5453,6 +5459,25 @@
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
+      }
+    },
+    "eslint-plugin-vuejs-accessibility": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-1.1.1.tgz",
+      "integrity": "sha512-vmXfZQMlVLLhoEd9WWOzzhwLKRFVOnteSsrWD/DGvIMUDZ9MkwB3gQ+sdSpjqYMC+bb68BPsp3YpNZBzygp9Xg==",
+      "dev": true,
+      "requires": {
+        "aria-query": "^5.0.0",
+        "emoji-regex": "^10.0.0",
+        "vue-eslint-parser": "^8.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.1.0.tgz",
+          "integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==",
+          "dev": true
+        }
       }
     },
     "eslint-scope": {
@@ -13774,6 +13799,71 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "vue-eslint-parser": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-8.3.0.tgz",
+      "integrity": "sha512-dzHGG3+sYwSf6zFBa0Gi9ZDshD7+ad14DGOdTLjruRVgZXe2J+DcZ9iUhyR48z5g1PqRa20yt3Njna/veLJL/g==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.2",
+        "eslint-scope": "^7.0.0",
+        "eslint-visitor-keys": "^3.1.0",
+        "espree": "^9.0.0",
+        "esquery": "^1.4.0",
+        "lodash": "^4.17.21",
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.7.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+          "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "eslint-scope": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+          "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^5.2.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+          "dev": true
+        },
+        "espree": {
+          "version": "9.3.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+          "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+          "dev": true,
+          "requires": {
+            "acorn": "^8.7.0",
+            "acorn-jsx": "^5.3.1",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        }
       }
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "eslint-config-prettier": "^8.x.x",
     "eslint-plugin-jest": "^24.3.5",
     "eslint-plugin-prettier": "^3.x.x",
+    "eslint-plugin-vuejs-accessibility": "^1.1.1",
     "jest": "^27.0.1",
     "lerna": "^3.22.1",
     "prettier": "^2.x.x"

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -86,7 +86,7 @@ This is the recommended configuration for Vue projects.
 Includes everything in the default config, plus environment specification and vue-specific rules.
 
 ```sh
-npm install --save-dev @lovetoknow/eslint-config @lovetoknow/prettier-config babel-eslint eslint eslint-config-prettier eslint-plugin-prettier prettier eslint-plugin-prettier-vue
+npm install --save-dev @lovetoknow/eslint-config @lovetoknow/prettier-config babel-eslint eslint eslint-config-prettier eslint-plugin-prettier prettier eslint-plugin-prettier-vue eslint-plugin-vuejs-accessibility
 ```
 
 **In your `.eslintrc`:** (or `.eslintrc.js`)
@@ -122,7 +122,7 @@ Includes everything in the default config, plus environment specification and vu
 - [`@nuxtjs/eslint-config`](https://github.com/nuxt/eslint-config/)
 
 ```sh
-npm install --save-dev @lovetoknow/eslint-config @lovetoknow/prettier-config babel-eslint eslint eslint-config-prettier eslint-plugin-prettier prettier @nuxtjs/eslint-config
+npm install --save-dev @lovetoknow/eslint-config @lovetoknow/prettier-config babel-eslint eslint eslint-config-prettier eslint-plugin-prettier prettier @nuxtjs/eslint-config eslint-plugin-vuejs-accessibility
 ```
 
 **In your `.eslintrc`:** (or `.eslintrc.js`)
@@ -584,6 +584,10 @@ This rule aims to enforce the self-closing sign as the configured style.
 See examples and more information here: https://eslint.vuejs.org/rules/html-self-closing.html
 
 </details>
+
+### Vue accessibility
+
+All rules from the [Vue a11y plugin](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility) are enforced and will be reported as warnings.
 
 ## Overriding Rules
 

--- a/packages/eslint-config/vue.js
+++ b/packages/eslint-config/vue.js
@@ -1,5 +1,19 @@
+const vueA11y = require('eslint-plugin-vuejs-accessibility')
+
+// Take all accessibility rules, but set them as warning only!
+const a11yAsWarning = Object.keys(vueA11y.rules).reduce(
+  (rules, ruleName) =>
+    Object.assign({}, rules, { [`vuejs-accessibility/${ruleName}`]: 1 }),
+  {}
+)
+
 module.exports = {
-  extends: ['plugin:vue/essential', './index.js'],
+  extends: [
+    'plugin:vue/essential',
+    './index.js',
+    'plugin:vuejs-accessibility/recommended',
+  ],
+  plugins: ['vuejs-accessibility'],
   parser: 'vue-eslint-parser',
   parserOptions: {
     sourceType: 'module',
@@ -10,44 +24,48 @@ module.exports = {
     node: true,
     es6: true,
   },
-  rules: {
-    'vue/no-use-v-if-with-v-for': [
-      'error',
-      {
-        allowUsingIterationVar: true,
-      },
-    ],
-    'vue/component-name-in-template-casing': ['error', 'kebab-case'],
-    'vue/attributes-order': [
-      'error',
-      {
-        order: [
-          'DEFINITION',
-          'LIST_RENDERING',
-          'UNIQUE',
-          'CONDITIONALS',
-          'RENDER_MODIFIERS',
-          'GLOBAL',
-          'SLOT',
-          'OTHER_DIRECTIVES',
-          'TWO_WAY_BINDING',
-          'CONTENT',
-          'OTHER_ATTR',
-          'EVENTS',
-        ],
-      },
-    ],
-    'vue/no-v-html': 'warn',
-    'vue/html-self-closing': [
-      'error',
-      {
-        html: { normal: 'always', void: 'always' },
-      },
-    ],
-    // Disabling some rules (also will affect Nuxt config)
-    'vue/html-closing-bracket-newline': 'off',
-    'vue/html-indent': 'off',
-    'vue/max-attributes-per-line': 'off',
-    'vue/singleline-html-element-content-newline': 'off', // not very friendly with prettier and the printWidth option
-  },
+  rules: Object.assign(
+    {},
+    {
+      'vue/no-use-v-if-with-v-for': [
+        'error',
+        {
+          allowUsingIterationVar: true,
+        },
+      ],
+      'vue/component-name-in-template-casing': ['error', 'kebab-case'],
+      'vue/attributes-order': [
+        'error',
+        {
+          order: [
+            'DEFINITION',
+            'LIST_RENDERING',
+            'UNIQUE',
+            'CONDITIONALS',
+            'RENDER_MODIFIERS',
+            'GLOBAL',
+            'SLOT',
+            'OTHER_DIRECTIVES',
+            'TWO_WAY_BINDING',
+            'CONTENT',
+            'OTHER_ATTR',
+            'EVENTS',
+          ],
+        },
+      ],
+      'vue/no-v-html': 'warn',
+      'vue/html-self-closing': [
+        'error',
+        {
+          html: { normal: 'always', void: 'always' },
+        },
+      ],
+      // Disabling some rules (also will affect Nuxt config)
+      'vue/html-closing-bracket-newline': 'off',
+      'vue/html-indent': 'off',
+      'vue/max-attributes-per-line': 'off',
+      'vue/singleline-html-element-content-newline': 'off', // not very friendly with prettier and the printWidth option
+    },
+    a11yAsWarning
+  ),
 }


### PR DESCRIPTION
…as warning

BREAKING CHANGE: apps/modules that consume this package will have to install eslint-plugin-vuejs-accessibility

## ℹ️ About

This is a 
# __` BREAKING CHANGE! `__

All eslint-plugin-vuejs-accessibility rules are added as warnings to our vue lint config.

## 🧪 How to test
- Checkout this branch, then run `npm pack` in `/packages/eslint-config`, a .tar file is generated
- In a project with Vue files where our eslint-config is already used, install  `eslint-plugin-vuejs-accessibility` then
- `npm i /path/to/tar-ball`
- Add some rule breaking code in a Vue component, e.g. `<input type="text"/>` without a label
- Run the lint job

Expected output:
line should be reported at warning level

---

- [ ] Has 🧪 tests
- [x] Has 📖 documentation


[🎫 Related Ticket](https://lovetoknow.atlassian.net/browse/FND-45)